### PR TITLE
Provide ItemLink for GameTooltip

### DIFF
--- a/gui/auction_listing.lua
+++ b/gui/auction_listing.lua
@@ -567,7 +567,7 @@ local methods = {
         local row = this:GetParent().row
         if row.record then
 	        GameTooltip:SetOwner(this, 'ANCHOR_RIGHT')
-            info.load_tooltip(GameTooltip, row.record.tooltip)
+            info.load_tooltip(GameTooltip, row.record.tooltip, row.record.link, row.record.item_id)
 	        tooltip.extend_tooltip(GameTooltip, row.record.link, row.record.aux_quantity)
             info.set_shopping_tooltip(row.record.slot)
         end


### PR DESCRIPTION
This PR adds itemLink and itemID for GameTooltip for addons that modify tooltips like [MopGearTooltips](https://github.com/Zebouski/MoPGearTooltips), [AtlasLoot](https://github.com/Otari98/AtlasLoot), [Tmog](https://github.com/Otari98/Tmog)